### PR TITLE
Add new repos to list

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,6 +16,13 @@
         "json-schema-validator-web-component", 
         "code-gov-about-page", 
         "code-gov-fscp-react-component", 
-        "code-gov-data"
+        "code-gov-data",
+        "code-gov-stats",
+        "code-gov-stats-jupyter-notebook",
+        "code-gov-verify-agency-jsons",
+        "code-gov-converter",
+        "code-gov-repo-template",
+        "code-gov-github-metrics",
+        "code-gov-open-source-toolkit"
     ]
 }


### PR DESCRIPTION
Add the following repos to the config.json so they will be included in the metrics data

code-gov-stats
code-gov-stats-jupyter-notebook
code-gov-verify-agency-jsons
code-gov-converter
code-gov-repo-template
code-gov-github-metrics
code-gov-open-source-toolkit

I did not remove code-gov-fscp-react-component or code-gov-about-page even though they are being deprecated because they were previously included in the metrics data (so excluding them now would lower our overall star, fork, and watch numbers)